### PR TITLE
Fix bad example

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ en el nombre de variable también.
 **Mal hecho:**
 ```javascript
 const Coche = {
-  marca: 'Honda',
-  modelo: 'Accord',
-  color: 'Blue'
+  cocheMarca: 'Honda',
+  cocheModelo: 'Accord',
+  cocheColor: 'Blue'
 };
 
 function pintarCoche(coche) {
-  coche.color = 'Red';
+  coche.cocheColor = 'Red';
 }
 ```
 


### PR DESCRIPTION
The bad example on "No incluyas contexto innecesario" was the same that in good example.